### PR TITLE
Removed dead code that's colliding with new code in IntelliJ 2016.3

### DIFF
--- a/plugin/src/main/kotlin/org/jetbrains/spek/idea/SpekRunConfiguration.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/spek/idea/SpekRunConfiguration.kt
@@ -50,11 +50,6 @@ class SpekRunConfiguration(javaRunConfigurationModule: JavaRunConfigurationModul
         var isAlternativeJrePathEnabled: Boolean
     )
 
-    private val searchScope: GlobalSearchScope
-        get() {
-            return configurationModule.searchScope
-        }
-
     override fun getValidModules(): MutableCollection<Module> {
         return Arrays.asList(*ModuleManager.getInstance(project).modules)
     }


### PR DESCRIPTION
Some dead code collides with new code in IntelliJ 2016.3, preventing run configurations from working.
fixes #20