### PR TITLE
Run the spek under cursor when "Run context configuration" occurs

### DIFF
--- a/plugin/src/main/kotlin/org/jetbrains/spek/idea/SpekUtils.kt
+++ b/plugin/src/main/kotlin/org/jetbrains/spek/idea/SpekUtils.kt
@@ -2,6 +2,7 @@ package org.jetbrains.spek.idea
 
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.PsiUtil
 import org.jetbrains.kotlin.asJava.classes.KtLightClass
 import org.jetbrains.kotlin.asJava.toLightClass
@@ -13,6 +14,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtLambdaArgument
 import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
@@ -78,6 +80,15 @@ object SpekUtils {
     fun isJUnit4(cls: KtClassOrObject): Boolean {
         val fqName = FqName("org.junit.runner.RunWith")
         return cls.findAnnotation(fqName) != null
+    }
+
+    fun isInKotlinFile(element: PsiElement): Boolean {
+        val file = PsiTreeUtil.getParentOfType(element, KtFile::class.java)
+        return file != null
+    }
+
+    fun isGroupOrTest(function: KtNamedFunction): Boolean {
+        return isGroup(function) || isTest(function)
     }
 
     fun isGroup(function: KtNamedFunction): Boolean {

--- a/tooling/src/main/kotlin/org/jetbrains/spek/tooling/Path.kt
+++ b/tooling/src/main/kotlin/org/jetbrains/spek/tooling/Path.kt
@@ -20,4 +20,30 @@ class Path(@JsonProperty("type") val type: PathType,
 
         fun deserialize(path: String): Path = mapper.readValue(path)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+
+        if (other?.javaClass != javaClass) {
+            return false
+        }
+
+        other as Path
+
+        if (this.type != other.type) {
+            return false
+        }
+
+        if (this.description != other.description) {
+            return false
+        }
+
+        if (this.next != other.next) {
+            return false
+        }
+
+        return true
+    }
 }


### PR DESCRIPTION
We noticed that while the plugin adds green arrows to the gutter for running specs, it doesn't do anything when you "Run context configuration" (normally bound to `ctrl + shift + R` on OSX).

We've added more logic to `setupConfigurationFromContext` and `isConfigurationFromContext` that attempts to find the containing Spek block for the cursor position so that the appropriate Spek will be run.

We also noticed that run configurations weren't successfully being recycled even when using the gutter arrows, so we added an equality test for Path objects to ensure that the number of run configurations won't continue to grow as you run tests.