### PR TITLE
Bump gradle-intellij-plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "gradle.plugin.com.zoltu.gradle.plugin:git-versioning:2.0.21"
-        classpath "gradle.plugin.org.jetbrains:gradle-intellij-plugin:0.1.10"
+        classpath "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.2.12"
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
     }
 }


### PR DESCRIPTION
The old version was causing problems when downloading the
kotlin plugin due to the server now including query string
parameters in the downloaded .zip filename

See issue: https://github.com/JetBrains/gradle-intellij-plugin/issues/201

Particularly, if we download this project fresh and run `gradle` we get an error like this:
```
 → gradle

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':plugin'.
> Invalid type of downloaded plugin: /var/folders/7s/mdwxcrws4ng1km3smqrh6zrc0000gn/T/intellij474753869254598434/kotlin-plugin-1.0.4-release-IJ2016.1-112.zip?updateId=28547&pluginId=6954

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 11.46 secs
```

Note that this problem may not occur if you have a cached `kotlin-plugin` from previous builds in `~/.gradle` -- it needs to be downloading a fresh copy