### PR TITLE
Fix IDE error: com.intellij.diagnostic.PluginException:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven { url 'http://dl.bintray.com/jetbrains/intellij-plugin-service' }
-        maven { url 'http://dl.bintray.com/kotlin/kotlin-eap-1.1' }
+        maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
@@ -29,11 +29,7 @@ subprojects {
 
     repositories {
         mavenCentral()
-        maven {
-            url "https://dl.bintray.com/jetbrains/spek"
-        }
-        maven { url 'http://dl.bintray.com/kotlin/kotlin-eap-1.1' }
-
+        maven { url "https://www.jetbrains.com/intellij-repository/releases" }
     }
 }
 

--- a/plugin-idea/src/main/kotlin/org/jetbrains/spek/idea/SpekJvmConfigurationFactory.kt
+++ b/plugin-idea/src/main/kotlin/org/jetbrains/spek/idea/SpekJvmConfigurationFactory.kt
@@ -7,6 +7,9 @@ import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.openapi.project.Project
 
 class SpekJvmConfigurationFactory(type: ConfigurationType): ConfigurationFactory(type) {
+
+    override fun getId(): String = type.id
+
     override fun createTemplateConfiguration(project: Project): RunConfiguration =
         SpekJvmRunConfiguration(JavaRunConfigurationModule(project, true), this, "Un-named")
 }


### PR DESCRIPTION
 The default implementation of method 'getId' is deprecated, you need to override it in 'class org.jetbrains.spek.idea.SpekJvmConfigurationFactory'. The default implementation delegates to 'getName' which may be localized, but return value of this method must not depend on current localization. [Plugin: org.jetbrains.spek.spek-idea-plugin]